### PR TITLE
SWCR007 Lower bound and revised base case

### DIFF
--- a/commercial measures/SWCR007-05 Float Temp Ctrl/SWCR007-05 Float Temp Ctrl_Ex/cases/Gro&0&cDXGF&Ex&Ref_Storage__RefControl.csv
+++ b/commercial measures/SWCR007-05 Float Temp Ctrl/SWCR007-05 Float Temp Ctrl_Ex/cases/Gro&0&cDXGF&Ex&Ref_Storage__RefControl.csv
@@ -1,10 +1,10 @@
-skip,case_name,:refsys_condenser_type,:refsys_cond_fan_speed_control_type,:refsys_cond_sct_delta,:refsys_cond_floating
-#,defaults,,,,
-,NE-Ref_Storage-RefControl-FltCondTemp-AirCool ,AirCooled,TwoSpeed,6.67,TRUE
-,NE-Ref_Storage-RefControl-FixCondTemp-AirCool ,AirCooled,TwoSpeed,6.67,FALSE
-,NE-Ref_Storage-RefControl-FltCondTemp-AirCool-VSDFan ,AirCooled,VariableSpeed,6.67,TRUE
-,NE-Ref_Storage-RefControl-FixCondTemp-AirCool-VSDFan ,AirCooled,VariableSpeed,6.67,FALSE
-,NE-Ref_Storage-RefControl-FltCondTemp-EvapCool ,EvaporativelyCooled,TwoSpeed,9.44,TRUE
-,NE-Ref_Storage-RefControl-FixCondTemp-EvapCool ,EvaporativelyCooled,TwoSpeed,9.44,FALSE
-,NE-Ref_Storage-RefControl-FltCondTemp-EvapCool-VSDFan ,EvaporativelyCooled,VariableSpeed,9.44,TRUE
-,NE-Ref_Storage-RefControl-FixCondTemp-EvapCool-VSDFan ,EvaporativelyCooled,VariableSpeed,9.44,FALSE
+skip,case_name,:refsys_condenser_type,:refsys_cond_fan_speed_control_type,:refsys_cond_sct_delta,:refsys_cond_floating,:refsys_cond_min_temp
+#,defaults,,,,,
+,NE-Ref_Storage-RefControl-FltCondTemp-AirCool ,AirCooled,TwoSpeed,6.67,TRUE,21.11
+,NE-Ref_Storage-RefControl-FixCondTemp-AirCool ,AirCooled,TwoSpeed,6.67,FALSE,26.66
+,NE-Ref_Storage-RefControl-FltCondTemp-AirCool-VSDFan ,AirCooled,VariableSpeed,6.67,TRUE,21.11
+,NE-Ref_Storage-RefControl-FixCondTemp-AirCool-VSDFan ,AirCooled,VariableSpeed,6.67,FALSE,26.66
+,NE-Ref_Storage-RefControl-FltCondTemp-EvapCool ,EvaporativelyCooled,TwoSpeed,9.44,TRUE,21.11
+,NE-Ref_Storage-RefControl-FixCondTemp-EvapCool ,EvaporativelyCooled,TwoSpeed,9.44,FALSE,26.66
+,NE-Ref_Storage-RefControl-FltCondTemp-EvapCool-VSDFan ,EvaporativelyCooled,VariableSpeed,9.44,TRUE,21.11
+,NE-Ref_Storage-RefControl-FixCondTemp-EvapCool-VSDFan ,EvaporativelyCooled,VariableSpeed,9.44,FALSE,26.66

--- a/prototypes/Gro/templates/root.pxt
+++ b/prototypes/Gro/templates/root.pxt
@@ -647,7 +647,7 @@ end
 # Behzad Rizi, 05/03/2024 - added new parameters "suction_temperature_control" and "cond_fan_speed_control_type"
 # Behzad Rizi, 11/11/2024 - added new parameters "cond_sct_delta" and "cond_floating"
 import "ref-sys.pxt", :group => "refsys", :prefix => "refsys_" do
-  include "cond_fan_power|cond_subcool|working_fluid|condenser_type|suction_temperature_control|cond_fan_speed_control_type|cond_sct_delta|cond_floating"
+  include "cond_fan_power|cond_subcool|working_fluid|condenser_type|suction_temperature_control|cond_fan_speed_control_type|cond_sct_delta|cond_floating|cond_min_temp"
 end
 
 import "ref-comp.pxt", :group => "refcomp", :prefix => "refcomp_" do

--- a/templates/energyplus/templates/ref-sys.pxt
+++ b/templates/energyplus/templates/ref-sys.pxt
@@ -20,6 +20,7 @@ parameter "cond_fan_speed_control_type", :default=>"TwoSpeed" # (TwoSpeed | Fixe
 parameter "cond_sct_delta", :default=>12 # in ['degF']
 #Behzad Rizi - parameterize activation mode for EMS object to control the saturated condensing temperature(SCT)
 parameter "cond_floating", :default=>false, :domain => Boolean # (true | false)
+parameter "cond_min_temp", :default=>25['C']
 %>
 
 <%
@@ -41,7 +42,7 @@ Refrigeration:System,
  <%   raise("error: unknown option condenser_type = '#{condenser_type}'") %>
  <% end %>
     <%= ref_sys_comp_list %>,   !- Compressor or CompressorList Name
-    25.0,                    !- Minimum Condensing Temperature {C}
+    <%= cond_min_temp %>,                    !- Minimum Condensing Temperature {C}
     <%= working_fluid %>,                     !- Refrigeration System Working Fluid Type
     <%= suction_temperature_control %>,  !- Suction Temperature Control Type
     ,                        !- Mechanical Subcooler Name
@@ -160,5 +161,6 @@ EnergyManagementSystem:ProgramCallingManager,
 	
 EnergyManagementSystem:Program,	
 CondTempControl<%= ref_system_name %>,       !- Name
-SET CondensingTempOverride<%= ref_system_name %> = T_sensor_<%= ref_system_name %> + <%= cond_sct_delta %>;  !- Program Line 1
+SET CondensingTempOverride<%= ref_system_name %> = T_sensor_<%= ref_system_name %> + <%= cond_sct_delta %>,  !- Program Line 1
+SET CondensingTempOverride<%= ref_system_name %> = @Max <%= cond_min_temp %> CondensingTempOverride<%= ref_system_name %>;  !- Program Line 2
 <% end %>


### PR DESCRIPTION
* Follow up to #3
* Create new parameter `cond_min_temp` to replace hard-coded value of 25 °C in template `ref-sys.pxt`.
* Modify EMS control logic for condenser minimum temperature reset function to set a lower bound.
* Set values for base case to 80 °F (26.66 °C) matching DEER2020/MASControl assumption for commercial vintages since 2007
* Set values for measure case to 70 °F (21.11 °C) matching SWCR007-04 measure definition

Note that DEER2020 default logic is a function of building code vintage as follows:

vintage | AirCondSCT (°F) | EvapCondSCT (°F) |
--- | --- | --- |
1975 | 90 | 95 |
1985 | 90 | 95 |
1996 | 90 | 90 |
2003 | 85 | 85 |
2007 | 80 | 80 |
2011 | 80 | 80 |
&gt;2011 | 80 | 80 |



