### PR TITLE
Result2 script enhancements - DEER peak definition and long output

### DIFF
--- a/scripts/result2.py
+++ b/scripts/result2.py
@@ -260,8 +260,16 @@ def build_query_with_special_cases(resultspec: ResultSpec, finalize = True) -> s
     return query, agg_columns
 
 
-def get_sim_hourly(conn: Connection):
+def get_sim_hourly(conn: Connection, column_filter=None):
     """Get simulation hourly results from one EnergyPlus SQLite output file.
+
+    Inputs:
+        conn: sqlite3.Connection | str
+            Database file connection or string path to EnergyPlus SQLite output file.
+            Note that this function does not read CSV output files.
+        column_filter: None | List[str]
+            List of hourly output column names to include.
+            If None, all output columns in the file are included.
 
     Returns:
         ReportDataWide: pandas.DataFrame
@@ -286,11 +294,6 @@ def get_sim_hourly(conn: Connection):
     """
 
     ReportDataDictionary = pd.read_sql_query('select * from ReportDataDictionary', conn, index_col='ReportDataDictionaryIndex')
-    #n_rows, = conn.execute('select count(*) from ReportData').fetchone()
-    chunks = []
-    for chunk in pd.read_sql_query('select * from ReportData', conn, chunksize=10000):
-        chunks.append(chunk)
-    ReportData = pd.concat(chunks, axis=0)
 
     # Transform ReportDataDictionary so we have a single column lookup string.
     # LookupKey looks like:
@@ -300,6 +303,24 @@ def get_sim_hourly(conn: Connection):
         lambda x: f'{x.KeyValue}:{x.Name} [{x.Units}]({x.ReportingFrequency})' if bool(x.KeyValue)
         else f'{x.Name} [{x.Units}]({x.ReportingFrequency})'
         , axis=1)
+
+    query_report_data = 'select * from ReportData'
+
+    rd_indices = []
+    if column_filter:
+        # Construct a list of ReportDataDictionaryIndex values from column_filter.
+        # Note that ReportDataDictionaryIndex values are file-specific.
+        rd_indices = ReportDataDictionary[ReportDataDictionary['LookupKey'].isin(column_filter)].index
+        placeholders = ', '.join(['?'] * len(rd_indices))
+        query_report_data += f''' where "ReportDataDictionaryIndex" in ({placeholders})'''
+
+    #n_rows, = conn.execute('select count(*) from ReportData').fetchone()
+    chunks = []
+    for chunk in pd.read_sql_query(query_report_data, conn, chunksize=10000,
+                                   params=tuple(rd_indices) if column_filter else None):
+        chunks.append(chunk)
+    ReportData = pd.concat(chunks, axis=0)
+
     ReportData2 = ReportData.join(ReportDataDictionary, on='ReportDataDictionaryIndex')
 
     # Transform ReportData from long to wide so we can make a condensed table
@@ -310,7 +331,7 @@ def get_sim_hourly(conn: Connection):
 
     return ReportDataWide
 
-def get_sim_deer_peak(conn: Connection, bldgloc: str):
+def get_sim_deer_peak(conn: Connection, bldgloc: str, column_filter=DEERPEAK_COLUMNS):
     """Get simulation DEER Peak results from one EnergyPlus SQLite output file.
 
     Inputs:
@@ -324,8 +345,8 @@ def get_sim_deer_peak(conn: Connection, bldgloc: str):
             of the hourly variable named `k` over the DEER Peak Period.
     """
     # Get all available hourly results with shape (N, 8760)
-    ReportDataWide = get_sim_hourly(conn)
-    ReportDataWide = ReportDataWide.loc[DEERPEAK_COLUMNS]
+    ReportDataWide = get_sim_hourly(conn, column_filter=column_filter)
+    #ReportDataWide = ReportDataWide.loc[DEERPEAK_COLUMNS]
     if ReportDataWide.shape[1] != 8760:
         # No hourly data. This can happen if simulation created the output file but failed to complete.
         # Or if the file represents a sizing run.

--- a/scripts/result2.py
+++ b/scripts/result2.py
@@ -841,7 +841,7 @@ def build_cli_parser(parser: argparse.ArgumentParser,
     #                    help=r'Output file, e.g. simdata.csv',
     #                    **outputfile_kwargs)
     parser.add_argument('-P', '--parallel', action='store_false', help='Disable parallel mode.')
-    parser.add_argument('-s', '--sqlite', action='store_true', help='Write output in SQLite format.')
+    parser.add_argument('-w', '--wide', action='store_true', help='Write output in wide csv format.')
     parser.add_argument('-t', '--tabular', action='store_true', help='If writing to SQLite, store data in tabular (long) format.')
     parser.add_argument('-l', '--long', action='store_true', help='If writing to CSV, store data in tabular (long) format.')
 
@@ -850,15 +850,14 @@ def cli_main():
     parser = argparse.ArgumentParser()
     build_cli_parser(parser)
     pargs = parser.parse_args()
-    if pargs.sqlite:
-        if pargs.tabular:
-            gather_sim_data_to_sqlite_long(pargs.study, pargs.queryfile, 'simdata.sqlite', pargs.parallel)
-        else:
-            gather_sim_data_to_sqlite(pargs.study, pargs.queryfile, 'simdata.sqlite', pargs.parallel)
-    elif pargs.long:
-        gather_sim_data_to_csv_long(pargs.study, pargs.queryfile, 'simdata_long.csv',)
-    else:
+    if pargs.wide:
         gather_sim_data_to_csv(pargs.study, pargs.queryfile, 'simdata.csv', pargs.parallel)
+    elif pargs.long:
+        gather_sim_data_to_csv_long(pargs.study, pargs.queryfile, 'simdata.csv', pargs.parallel)
+    elif pargs.tabular:
+        gather_sim_data_to_sqlite(pargs.study, pargs.queryfile, 'simdata.sqlite',)
+    else:
+        gather_sim_data_to_sqlite_long(pargs.study, pargs.queryfile, 'simdata.sqlite', pargs.parallel)
 
 def gooey_main():
     """Opens a window for user to input options and start the script."""

--- a/scripts/result2.py
+++ b/scripts/result2.py
@@ -520,6 +520,7 @@ def get_runs_instances(study: Path, search_pattern = '**/instance*-out.sql', exc
         # Try to get additional metadata, but don't fail if it doesn't match.
         patterns = [
             r'(.*/)?runs[^/]*/(?P<BldgLoc>CZ\d\d)/(?P<Cohort>[^/]+)/(?P<Case>[^/]+)/instance.*',
+            r'(.*/)?runs[^/]*/(?P<BldgLoc>CZ\d\d)/(?P<BldgType>\w+)&(?P<Story>\w+)&(?P<BldgHVAC>\w+)&(?P<BldgVint>[\w\-]+)&(?P<TechGroup>[\w\-]+)/(?P<TechID>[^/]+)/instance.*',
             r'(.*/)?runs[^/]*/(?P<BldgLoc>CZ\d\d)/(?P<BldgType>\w+)&(?P<Story>\w+)&(?P<BldgHVAC>\w+)&(?P<BldgVint>[\w\-]+)&(?P<TechGroup>[\w\-]+)__(?P<TechType>[\w\-]+)/(?P<TechID>[^/]+)/instance.*',
             r'(.*/)?runs[^/]*/(?P<BldgLoc>CZ\d\d)/(?P<BldgType>\w+)&(?P<Story>\w+)&(?P<BldgHVAC>\w+)&(?P<BldgVint>[\w\-]+)&(?P<TechGroupUnused>[\w\-]+)__(?P<TechTypeUnused>[\w\-]+)&(?P<TechGroup>[\w\-]+)__(?P<TechType>[\w\-]+)/(?P<TechID>[^/]+)/instance.*',
         ]

--- a/scripts/result2.py
+++ b/scripts/result2.py
@@ -803,6 +803,15 @@ def gather_sim_data_to_sqlite_long(study: Path, queryfile: Path, sqlfile: Path,
             with conn:
                 df_metadata.to_sql('sim_metadata', conn, index=False, if_exists='append')
                 tabular_data.to_sql('sim_tabular', conn, index=False, if_exists='append')
+        # Save a Wide format table to CSV for manual review purposes
+        # The query script combines units into the column names and only provides columns with data.
+        script = Path("result2_helper_long2wide.sql").read_text()
+        with conn:
+            longTableForReview = pd.read_sql_query(script, conn)
+            # Convert from long format to wide format
+            wideTableForReview = longTableForReview.pivot(
+                index=['filename'],columns=['ColumnUnits'],values=['Values'])
+            wideTableForReview.to_csv('wideTableForReview.csv', index=None)
 
     finally:
         conn.close()

--- a/scripts/result2.py
+++ b/scripts/result2.py
@@ -822,15 +822,6 @@ def gather_sim_data_to_sqlite_long(study: Path, queryfile: Path, sqlfile: Path,
             with conn:
                 df_metadata.to_sql('sim_metadata', conn, index=False, if_exists='append')
                 tabular_data.to_sql('sim_tabular', conn, index=False, if_exists='append')
-        # Save a Wide format table to CSV for manual review purposes
-        # The query script combines units into the column names and only provides columns with data.
-        script = Path("result2_helper_long2wide.sql").read_text()
-        with conn:
-            longTableForReview = pd.read_sql_query(script, conn)
-            # Convert from long format to wide format
-            wideTableForReview = longTableForReview.pivot(
-                index=['filename'],columns=['ColumnUnits'],values=['Values'])
-            wideTableForReview.to_csv('wideTableForReview.csv', index=None)
 
     finally:
         conn.close()
@@ -864,7 +855,7 @@ def cli_main():
     elif pargs.long:
         gather_sim_data_to_csv_long(pargs.study, pargs.queryfile, 'simdata.csv', pargs.parallel)
     elif pargs.tabular:
-        gather_sim_data_to_sqlite(pargs.study, pargs.queryfile, 'simdata.sqlite',)
+        gather_sim_data_to_sqlite(pargs.study, pargs.queryfile, 'simdata_long.sqlite', pargs.paralell)
     else:
         gather_sim_data_to_sqlite_long(pargs.study, pargs.queryfile, 'simdata.sqlite', pargs.parallel)
 

--- a/scripts/result2.py
+++ b/scripts/result2.py
@@ -543,6 +543,26 @@ def get_runs_instances(study: Path, search_pattern = '**/instance*-out.sql', exc
         Default metadata fields:
             'File Name'
                 File path relative to study folder, with forward slashes.
+            'BldgLoc'
+                CEC Climate Zone (CZ01, CZ02, ..., CZ16)
+            'BldgType'
+                Prototype name code (Asm, ... SUn)
+            'Story'
+                Number of stories (1 or 2 for single family, 0 for all other building types)
+            'BldgHVAC'
+                HVAC type code found in cohort name (rDXGF, ...)
+            'BldgVint'
+                Vintage code found in cohort name (Ex, New)
+            'TechGroup'
+                Technology group found in cohort name (SpaceHtg_eq, ...)
+            'TechType'
+                Technology type found in cohort name (GasFurnace, ...)
+            'TechID'
+                Name for a set of input parameters , a.k.a. case_name (Msr-Res-GasFurnace-AFUE95-ECM)
+            'Cohort'
+                The entire cohort name (SFm&1&rDXGF&Ex&SpaceHtg_eq__GasFurnace)
+            'Case'
+                The case name
     """
     if not isinstance(study, Path):
         study = Path(study)

--- a/scripts/result2.py
+++ b/scripts/result2.py
@@ -841,9 +841,9 @@ def build_cli_parser(parser: argparse.ArgumentParser,
     #                    help=r'Output file, e.g. simdata.csv',
     #                    **outputfile_kwargs)
     parser.add_argument('-P', '--parallel', action='store_false', help='Disable parallel mode.')
-    parser.add_argument('-w', '--wide', action='store_true', help='Write output in wide csv format.')
-    parser.add_argument('-t', '--tabular', action='store_true', help='If writing to SQLite, store data in tabular (long) format.')
-    parser.add_argument('-l', '--long', action='store_true', help='If writing to CSV, store data in tabular (long) format.')
+    parser.add_argument('-c', '--csv', action='store_true', help='Write output in wide csv format.')
+    parser.add_argument('-w', '--wide', action='store_true', help='If writing to SQLite, store data in wide format.')
+    parser.add_argument('-t', '--tabular', action='store_true', help='If writing to CSV, store data in tabular (long) format.')
 
 def cli_main():
     """Starts the script on command line."""
@@ -852,10 +852,10 @@ def cli_main():
     pargs = parser.parse_args()
     if pargs.wide:
         gather_sim_data_to_csv(pargs.study, pargs.queryfile, 'simdata.csv', pargs.parallel)
-    elif pargs.long:
-        gather_sim_data_to_csv_long(pargs.study, pargs.queryfile, 'simdata.csv', pargs.parallel)
     elif pargs.tabular:
-        gather_sim_data_to_sqlite(pargs.study, pargs.queryfile, 'simdata_long.sqlite', pargs.parallel)
+        gather_sim_data_to_csv_long(pargs.study, pargs.queryfile, 'simdata.csv', pargs.parallel)
+    elif pargs.wide:
+        gather_sim_data_to_sqlite(pargs.study, pargs.queryfile, 'simdata.sqlite', pargs.parallel)
     else:
         gather_sim_data_to_sqlite_long(pargs.study, pargs.queryfile, 'simdata.sqlite', pargs.parallel)
 
@@ -873,10 +873,10 @@ def gooey_main():
     pargs = parser.parse_args()
     if pargs.wide:
         gather_sim_data_to_csv(pargs.study, pargs.queryfile, 'simdata.csv', pargs.parallel)
-    elif pargs.long:
-        gather_sim_data_to_csv_long(pargs.study, pargs.queryfile, 'simdata.csv', pargs.parallel)
     elif pargs.tabular:
-        gather_sim_data_to_sqlite(pargs.study, pargs.queryfile, 'simdata_long.sqlite', pargs.parallel)
+        gather_sim_data_to_csv_long(pargs.study, pargs.queryfile, 'simdata.csv', pargs.parallel)
+    elif pargs.wide:
+        gather_sim_data_to_sqlite(pargs.study, pargs.queryfile, 'simdata.sqlite', pargs.parallel)
     else:
         gather_sim_data_to_sqlite_long(pargs.study, pargs.queryfile, 'simdata.sqlite', pargs.parallel)
 

--- a/scripts/result2.py
+++ b/scripts/result2.py
@@ -855,7 +855,7 @@ def cli_main():
     elif pargs.long:
         gather_sim_data_to_csv_long(pargs.study, pargs.queryfile, 'simdata.csv', pargs.parallel)
     elif pargs.tabular:
-        gather_sim_data_to_sqlite(pargs.study, pargs.queryfile, 'simdata_long.sqlite', pargs.paralell)
+        gather_sim_data_to_sqlite(pargs.study, pargs.queryfile, 'simdata_long.sqlite', pargs.parallel)
     else:
         gather_sim_data_to_sqlite_long(pargs.study, pargs.queryfile, 'simdata.sqlite', pargs.parallel)
 
@@ -871,15 +871,14 @@ def gooey_main():
           #outputfile_kwargs = dict(widget='FileChooser')
           )
     pargs = parser.parse_args()
-    if pargs.sqlite:
-        if pargs.tabular:
-            gather_sim_data_to_sqlite_long(pargs.study, pargs.queryfile, 'simdata.sqlite', pargs.parallel)
-        else:
-            gather_sim_data_to_sqlite(pargs.study, pargs.queryfile, 'simdata.sqlite', pargs.parallel)
-    elif pargs.long:
-        gather_sim_data_to_csv_long(pargs.study, pargs.queryfile, 'simdata_long.csv',)
-    else:
+    if pargs.wide:
         gather_sim_data_to_csv(pargs.study, pargs.queryfile, 'simdata.csv', pargs.parallel)
+    elif pargs.long:
+        gather_sim_data_to_csv_long(pargs.study, pargs.queryfile, 'simdata.csv', pargs.parallel)
+    elif pargs.tabular:
+        gather_sim_data_to_sqlite(pargs.study, pargs.queryfile, 'simdata_long.sqlite', pargs.parallel)
+    else:
+        gather_sim_data_to_sqlite_long(pargs.study, pargs.queryfile, 'simdata.sqlite', pargs.parallel)
 
 def test():
     """Starts the script with hard-coded options."""

--- a/scripts/result2.py
+++ b/scripts/result2.py
@@ -855,10 +855,15 @@ def gather_sim_data_to_sqlite_long(study: Path, queryfile: Path, sqlfile: Path,
         conn.close()
 
 # Added by kyen on 1-14-26 for long table csv option
-def gather_sim_data_to_csv_long(study: Path, queryfile: Path, csvfile: Path,
-                           parallel = True,
-                           chunksize = 100):
-    conn = connect('simdata.sqlite')
+def gather_sim_data_to_csv_long(
+        sqlfile : Path = 'simdata.sqlite',
+        csvfile : Path = 'simdata.csv'):
+    """Save a CSV report (simdata.csv) in long table format for use in other calculations.
+    
+    Requires that data are already stored in long table format in a database file (simdata.sqlite)."""
+
+    pass
+    conn = connect(sqlfile)
     cursor = conn.cursor()
     # Execute a query to get the data
     cursor.execute("SELECT * FROM sim_tabular")
@@ -867,7 +872,7 @@ def gather_sim_data_to_csv_long(study: Path, queryfile: Path, csvfile: Path,
     # Convert to DataFrame
     df = pd.DataFrame(rows, columns=[column[0] for column in cursor.description])
     # Write dataframe to CSV
-    df.to_csv('simdata.csv', index=False)
+    df.to_csv(csvfile, index=False)
     
     # #Scratch work for pargs
     # gather = gather_sim_data_to_sqlite(study, queryfile, parallel)

--- a/scripts/result2.py
+++ b/scripts/result2.py
@@ -20,6 +20,7 @@ Changelog
     * 2025-01-07 Apply DEER Peak calculation more selectively
     * 2025-07-24 Filename pattern matching revised for better consistency between different conventions
     * 2026-01-19 Column names updated to improve consistency across models
+    * 2026-03-03 Added options for DEER Peak demand: E-5152 (original behavior) and E-5350
 
 @Author: Nicholas Fette <nfette@solaris-technical.com>
 @Date: 2024-05-01
@@ -30,6 +31,9 @@ Changelog
 DEERPEAK_COLUMNS = ["Electricity:Facility [J](Hourly)"]
 # Do you want to append "(units)"" in the column name, if available?
 APPEND_UNITS = False
+# Which definition of peak period dates to use?
+PEAK_VERSION = 'E5152' # 'E5152', 'E5350'
+
 
 ##STEP 0: Setup (import all necessary libraries)
 import re
@@ -57,8 +61,10 @@ import numpy as np
 import pandas as pd
 import tqdm
 
-def get_deer_peak_day(bldgloc: str):
+def get_deer_peak_day_E5152(bldgloc: str):
     """Return a for DEER peak period start day lookups.
+    Dates are from Resolution E-5152 (DEER2023) Attachment A, Table A-3-2.
+    The dates were derived using CZ2022 weather data.
 
     Input:
         BldgLoc: str
@@ -88,9 +94,42 @@ def get_deer_peak_day(bldgloc: str):
     ])
     return peakperspec[bldgloc]
 
+def get_deer_peak_day_E5350(bldgloc: str):
+    """Return a for DEER peak period start day lookups.
+    Dates are from Resolution E-5350 (DEER2026) Attachment A, Table A-1-5.
+    The dates were derived using CZ2022 weather data.
+
+    Input:
+        BldgLoc: str
+            CEC climate zone, e.g. CZ01 through CZ16.
+
+    Returns:
+        PkDay: int
+            1-based day number index for first day of the 3-day DEER peak period.
+    """
+    peakperspec = dict([
+        ("CZ01",238),
+        ("CZ02",238),
+        ("CZ03",238),
+        ("CZ04",238),
+        ("CZ05",259),
+        ("CZ06",180),
+        ("CZ07",245),
+        ("CZ08",245),
+        ("CZ09",245),
+        ("CZ10",180),
+        ("CZ11",224),
+        ("CZ12",180),
+        ("CZ13",180),
+        ("CZ14",180),
+        ("CZ15",180),
+        ("CZ16",224),
+    ])
+    return peakperspec[bldgloc]
+
 @cache
 def get_deer_peak_multipliers(BldgLoc: str,
-                          days=3, start_hr=16, end_hr=21, dst=True):
+                          days=3, start_hr=16, end_hr=21, dst=True, version=PEAK_VERSION):
     """Return a masking array useful to calculate an average over DEER Peak Period.
 
     Note that for compatibility, simulation data must be an 8760-length array
@@ -118,7 +157,12 @@ def get_deer_peak_multipliers(BldgLoc: str,
         dpm = deer_peak_multipliers('CZ11')
         dpload = sum(load_data * dpm)
     """
-    peak_day = get_deer_peak_day(BldgLoc)
+    if version == 'E5152':
+        peak_day = get_deer_peak_day_E5152(BldgLoc)
+    elif version == 'E5350':
+        peak_day = get_deer_peak_day_E5350(BldgLoc)
+    else:
+        raise ValueError(f'Unrecognized peak date version: {version}')
     # In case start_hr and end_hr are given in daylight saving time (DST), shift back to standard time.
     # time_dst = time_standard + 1
     start_hr -= 1 * dst

--- a/scripts/result2_helper_long2wide.sql
+++ b/scripts/result2_helper_long2wide.sql
@@ -1,0 +1,12 @@
+with ColumnUnits as (
+SELECT distinct "ColumnName", "Units"
+FROM "sim_tabular"
+)
+SELECT
+st.filename,
+cu."ColumnName" || " (" || cu."Units" || ")" as "ColumnUnits",
+sum(Value) as "Value"
+from sim_tabular st
+join ColumnUnits cu
+on st."ColumnName" = cu."ColumnName"
+group by st.filename, cu."ColumnName";


### PR DESCRIPTION
# Pull Request (PR) Description

For internal review and testing of updates to results2.py (query script with DEER peak demand).

Users identified challenges:

1. Output columns may be inconsistent across files where files match more than one naming pattern. This is because the function relies on regex pattern match to define which attribute columns are prepended to the results (e.g. BldgType, BldgHVAC, etc), and it fails quietly by falling back to a more generic pattern for backwards compatibility (cohort_name).
2. Output columns may be inconsistent across files where some files have results for a given query (from which column name or units can be inferred) and others don't. This is because the original script tries to extract column name and units from the EnergyPlus output file for a given query, but especially for component sizing, some models have no matching results and therefore no column name or units info for the given query.

One option to resolve these issues involves gathering data into three tables, and finalizing column names and units only after results from all files have been gathered:

1. During data collection:
  a. Write outputs in long table format (similar to EnergyPlus' own SQL output format).
  b. Writing separate tables for (a) instance attributes extracted from filename and (b) inferred column name and units.
2. After data collection, synthesize a wide format table by analyzing unique column names, matching up inferred units, 

A disadvantage of this approach is that it would introduce some additional processing time to finalize the wide format table since the current method (appending directly into one wide format table) is completely parallelizable. Other workarounds include prescribing instance attribute columns (blank if filename does not match pattern) and omitting inferred units in the column header.

# Desired features/changes

- [x] Make output columns consistent across multiple filename matching patterns
- [ ] Improve consistency of column names between models with and without results (units)
- [x] Change output file option so that script always writes to SQL first, and make CSV output optional
- [x] Logic to switch mode from peak day definitions per E-5152 (originally used in this script) to peak day definitions per E-5350. It is not necessary to support both modes, so this could be a controlled by a static variable at the module level. E-5350 dates are effective starting program year 2028.
- [x] Update the revision date in the file

# Review issues

- TBD
